### PR TITLE
Refactor app layout and implement multi-mode levels

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,305 +4,82 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Bonjour Couleur</title>
-    <style>
-        /* General Styles - Mobile First */
-        body {
-            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
-            background-color: #f0f4f8;
-            color: #333;
-            margin: 0;
-            padding: 1rem;
-            display: flex;
-            justify-content: center;
-            align-items: center;
-            min-height: 100vh;
-            text-align: center;
-            overflow: hidden;
-        }
-
-        .app-container {
-            width: 100%;
-            max-width: 400px;
-            background: white;
-            border-radius: 16px;
-            padding: 1.5rem;
-            box-shadow: 0 4px 20px rgba(0,0,0,0.1);
-        }
-
-        /* Screen Management */
-        .screen {
-            display: none; /* Hide all screens by default */
-        }
-        .screen.active {
-            display: block; /* Show only the active screen */
-        }
-
-        /* Input and Buttons */
-        h1 {
-            color: #2c3e50;
-        }
-        input[type="text"] {
-            width: calc(100% - 2rem);
-            padding: 0.75rem;
-            border: 2px solid #ddd;
-            border-radius: 8px;
-            font-size: 1.2rem;
-            text-align: center;
-            margin-bottom: 1rem;
-        }
-        button {
-            background-color: #3498db;
-            color: white;
-            border: none;
-            padding: 0.75rem 1.5rem;
-            border-radius: 8px;
-            font-size: 1.2rem;
-            cursor: pointer;
-            transition: background-color 0.3s;
-        }
-        button:hover {
-            background-color: #2980b9;
-        }
-        
-        /* Intro Screen Character and Bubble */
-        .intro-character-container {
-            position: relative;
-            margin-top: 2rem;
-            display: flex;
-            justify-content: center;
-            align-items: flex-end;
-            height: 120px;
-        }
-        .pixel-char {
-            width: 50px;
-            height: 70px;
-            background: #d9534f; /* Red body */
-            position: relative;
-            box-shadow: 
-                /* Hat */
-                0px -10px 0 0 #d9534f, 10px -10px 0 0 #d9534f, -10px -10px 0 0 #d9534f,
-                /* Face */
-                0px 0px 0 0 #f0ad4e,
-                /* Eyes */
-                -5px -5px 0 0 #fff, 5px -5px 0 0 #fff,
-                -5px -5px 0 1px #000, 5px -5px 0 1px #000,
-                /* Body */
-                -10px 10px 0 0 #337ab7, 10px 10px 0 0 #337ab7,
-                -10px 20px 0 0 #337ab7, 10px 20px 0 0 #337ab7;
-        }
-        .speech-bubble {
-            position: absolute;
-            background: #ecf0f1;
-            border-radius: 10px;
-            padding: 1rem;
-            font-size: 1.2rem;
-            bottom: 80px;
-            left: 50%;
-            transform: translateX(-50%);
-            width: 80%;
-            box-shadow: 0 2px 5px rgba(0,0,0,0.1);
-        }
-        .speech-bubble::after {
-            content: '';
-            position: absolute;
-            bottom: -10px;
-            left: 50%;
-            margin-left: -10px;
-            border-width: 10px;
-            border-style: solid;
-            border-color: #ecf0f1 transparent transparent transparent;
-        }
-
-        /* Game Screen Styles */
-        #game-header {
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-            margin-bottom: 1.5rem;
-            font-size: 1.2rem;
-        }
-        #color-prompt {
-            font-size: 1.5rem;
-            font-weight: bold;
-            color: #2c3e50;
-        }
-        .color-grid {
-            display: grid;
-            grid-template-columns: 1fr 1fr;
-            gap: 1rem;
-        }
-        .color-box {
-            height: 100px;
-            border-radius: 12px;
-            cursor: pointer;
-            border: 4px solid transparent;
-            transition: transform 0.2s, border-color 0.2s;
-        }
-        .color-box:hover {
-            transform: scale(1.05);
-        }
-        .color-box.correct {
-            border-color: #2ecc71;
-        }
-        .color-box.incorrect {
-            border-color: #e74c3c;
-        }
-
-    </style>
+    <link rel="stylesheet" href="style.css">
 </head>
 <body>
-
     <div class="app-container">
+        <header class="app-header">
+            <h1>Bonjour Couleur 2.0</h1>
+        </header>
 
-        <div id="name-screen" class="screen active">
-            <h1>Bonjour !</h1>
-            <p>Quel est ton nom ? (What is your name?)</p>
-            <input type="text" id="name-input" placeholder="Your Name">
-            <button onclick="startGame()">Commencer (Start)</button>
-        </div>
+        <main>
+            <section id="name-screen" class="screen active" aria-label="Name Entry">
+                <p>Quel est ton nom ? (What is your name?)</p>
+                <input type="text" id="name-input" placeholder="Ton nom" aria-label="Ton nom">
+                <button id="start-button">Commencer (Start)</button>
+            </section>
 
-        <div id="intro-screen" class="screen">
-            <div class="intro-character-container">
-                <div class="speech-bubble" id="intro-bubble"></div>
-                <div class="pixel-char"></div>
-            </div>
-        </div>
-
-        <div id="game-screen" class="screen">
-            <div id="game-header">
-                <span id="level-display">Level: 1</span>
-                <span id="score-display">Score: 0</span>
-            </div>
-            <p>Écoute la couleur et touche la bonne case.</p>
-            <p>(Listen to the color and touch the right box.)</p>
-            <button onclick="playPrompt()">Écouter (Listen) 🔊</button>
-            <div class="color-grid" id="color-grid">
+            <section id="intro-screen" class="screen" aria-label="Introduction">
+                <div class="intro-character-container">
+                    <div class="speech-bubble" id="intro-bubble"></div>
+                    <div class="pixel-char" aria-hidden="true"></div>
                 </div>
-        </div>
+            </section>
 
+            <section id="level-select-screen" class="screen" aria-label="Level Selection">
+                <h2>Choisis un niveau</h2>
+                <p id="player-greeting"></p>
+                <div id="level-grid" class="level-grid" role="list"></div>
+            </section>
+
+            <section id="game-screen" class="screen" aria-live="polite">
+                <div id="game-header" class="game-header">
+                    <button id="back-to-levels" class="ghost-button" aria-label="Retour aux niveaux">←</button>
+                    <div>
+                        <span id="level-display">Niveau 1</span>
+                        <span id="timer-display" class="timer hidden"></span>
+                    </div>
+                    <div class="score-panel">
+                        <span id="score-display">Score : 0</span>
+                        <button id="settings-button" class="ghost-button" aria-expanded="false" aria-controls="settings-panel">⚙️</button>
+                    </div>
+                </div>
+
+                <div id="instructions" class="instructions"></div>
+                <div id="color-prompt" class="color-prompt" role="status"></div>
+                <button id="listen-button" class="primary" type="button">Écouter 🔊</button>
+
+                <div id="color-grid" class="color-grid" role="list"></div>
+                <div id="memory-controls" class="memory-controls hidden">
+                    <button id="replay-sequence" class="primary" type="button">Rejouer la séquence 🔁</button>
+                </div>
+            </section>
+
+            <section id="level-complete-screen" class="screen" aria-label="Level Complete">
+                <h2 id="level-complete-title"></h2>
+                <div id="star-container" class="stars" aria-label="Score en étoiles"></div>
+                <p id="level-stats"></p>
+                <div class="level-complete-actions">
+                    <button id="next-level-button" class="primary">Niveau suivant</button>
+                    <button id="replay-level-button" class="ghost-button">Rejouer</button>
+                    <button id="back-to-map-button" class="ghost-button">Retour aux niveaux</button>
+                </div>
+            </section>
+        </main>
+
+        <aside id="settings-panel" class="settings hidden" aria-hidden="true">
+            <h2>Paramètres</h2>
+            <label class="toggle">
+                <input type="checkbox" id="speech-toggle" checked>
+                <span>Voix en français</span>
+            </label>
+            <p class="settings-hint">Les sons utilisent la synthèse vocale de ton navigateur.</p>
+            <button id="close-settings" class="ghost-button">Fermer</button>
+        </aside>
     </div>
 
-    <script>
-        // --- Global State ---
-        let playerName = '';
-        let currentLevel = 1;
-        let score = 0;
-        let currentCorrectColor = '';
+    <div id="toast" class="toast" role="alert" aria-live="assertive"></div>
 
-        // List of colors from the teacher's note
-        const colors = {
-            'rouge': '#e74c3c',
-            'bleu': '#3498db',
-            'vert': '#2ecc71',
-            'orange': '#e67e22',
-            'rose': '#ff79c6',
-            'jaune': '#f1c40f',
-            'marron': '#8d6e63',
-            'noir': '#2c3e50'
-        };
-        const colorNames = Object.keys(colors);
-
-        // --- Screen Management ---
-        function showScreen(screenId) {
-            document.querySelectorAll('.screen').forEach(screen => {
-                screen.classList.remove('active');
-            });
-            document.getElementById(screenId).classList.add('active');
-        }
-
-        // --- Game Start ---
-        function startGame() {
-            playerName = document.getElementById('name-input').value;
-            if (playerName.trim() === '') {
-                alert('S\'il te plaît, entre ton nom ! (Please enter your name!)');
-                return;
-            }
-            
-            // Show intro screen
-            document.getElementById('intro-bubble').textContent = `Allons-y, ${playerName} ! (Let's go!)`;
-            showScreen('intro-screen');
-
-            // After a short delay, move to the game screen
-            setTimeout(() => {
-                showScreen('game-screen');
-                setupLevel(currentLevel);
-            }, 2500); // 2.5 second delay
-        }
-        
-        // --- Level Setup ---
-        // This is a simple plan for 10 levels. We will only build Level 1 for now.
-        // Levels 1-2: Listen & Match 2 colors
-        // Levels 3-4: Listen & Match 4 colors
-        // Levels 5-6: Read & Match 4 colors
-        // Levels 7-8: Listen & Match word from 4 text choices
-        // Levels 9-10: Memory Game (sequence of colors)
-        function setupLevel(level) {
-            document.getElementById('level-display').textContent = `Level: ${level}`;
-            const grid = document.getElementById('color-grid');
-            grid.innerHTML = ''; // Clear previous boxes
-
-            let options = [];
-            let numOptions = 2; // For level 1, we start with 2 choices
-
-            // Get a random selection of unique colors
-            let availableColors = [...colorNames];
-            for (let i = 0; i < numOptions; i++) {
-                const randomIndex = Math.floor(Math.random() * availableColors.length);
-                options.push(availableColors.splice(randomIndex, 1)[0]);
-            }
-            
-            // Choose one of the options to be the correct answer
-            currentCorrectColor = options[Math.floor(Math.random() * options.length)];
-
-            // Create the color boxes on the screen
-            options.forEach(colorName => {
-                const colorBox = document.createElement('div');
-                colorBox.classList.add('color-box');
-                colorBox.style.backgroundColor = colors[colorName];
-                colorBox.dataset.color = colorName;
-                colorBox.addEventListener('click', handleColorChoice);
-                grid.appendChild(colorBox);
-            });
-
-            // Announce the color to find
-            setTimeout(playPrompt, 500);
-        }
-
-        // --- Audio Prompt ---
-        function playPrompt() {
-            // Use the browser's speech synthesis to say the word in French
-            const utterance = new SpeechSynthesisUtterance(currentCorrectColor);
-            utterance.lang = 'fr-FR';
-            speechSynthesis.speak(utterance);
-        }
-
-        // --- Handle Player's Choice ---
-        function handleColorChoice(event) {
-            const chosenColor = event.target.dataset.color;
-            
-            if (chosenColor === currentCorrectColor) {
-                // Correct!
-                score += 10;
-                event.target.classList.add('correct');
-                // Go to the next level/challenge after a short delay
-                setTimeout(() => {
-                    // For now, we just restart the same level for demonstration
-                    // In a full game, you would do currentLevel++
-                    setupLevel(currentLevel);
-                }, 1000);
-            } else {
-                // Incorrect
-                event.target.classList.add('incorrect');
-                // Remove the 'incorrect' style after a moment
-                setTimeout(() => {
-                    event.target.classList.remove('incorrect');
-                }, 1000);
-            }
-            
-            // Update the score display
-            document.getElementById('score-display').textContent = `Score: ${score}`;
-        }
-    </script>
-
+    <script src="script.js" defer></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,610 @@
+const STORAGE_KEY = 'bonjour-couleur-progress-v2';
+const LevelModes = {
+    LISTEN: 'listen',
+    READING: 'reading',
+    MEMORY: 'memory'
+};
+
+const COLOR_LIBRARY = {
+    rouge: '#e74c3c',
+    bleu: '#3498db',
+    vert: '#2ecc71',
+    orange: '#e67e22',
+    rose: '#ff79c6',
+    jaune: '#f1c40f',
+    marron: '#8d6e63',
+    noir: '#2c3e50',
+    blanc: '#ffffff',
+    gris: '#95a5a6',
+    violet: '#8e44ad',
+    turquoise: '#1abc9c',
+    beige: '#f5deb3'
+};
+
+const LEVELS = [
+    { id: 1, mode: LevelModes.LISTEN, rounds: 2, options: 2, timeLimit: 16000, instructions: 'Écoute la couleur et touche la bonne case.' },
+    { id: 2, mode: LevelModes.LISTEN, rounds: 3, options: 3, timeLimit: 14000, instructions: 'Plus rapide ! Écoute et trouve parmi trois couleurs.' },
+    { id: 3, mode: LevelModes.LISTEN, rounds: 3, options: 4, timeLimit: 12000, instructions: 'Encore plus de couleurs. Garde l\'oreille attentive !' },
+    { id: 4, mode: LevelModes.READING, rounds: 3, options: 4, timeLimit: 12000, instructions: 'Lis le mot et choisis la couleur correspondante.' },
+    { id: 5, mode: LevelModes.READING, rounds: 3, options: 5, timeLimit: 11000, instructions: 'Encore plus de lecture. Reste concentré !' },
+    { id: 6, mode: LevelModes.LISTEN, rounds: 4, options: 5, timeLimit: 10000, instructions: 'Mélange auditif et visuel : écoute vite et sélectionne !' },
+    { id: 7, mode: LevelModes.MEMORY, rounds: 1, sequenceLength: 3, options: 5, instructions: 'Observe la séquence de couleurs puis répète-la.' },
+    { id: 8, mode: LevelModes.MEMORY, rounds: 1, sequenceLength: 4, options: 6, instructions: 'La séquence est plus longue. Tu peux le faire !' },
+    { id: 9, mode: LevelModes.MEMORY, rounds: 1, sequenceLength: 5, options: 6, instructions: 'Attention à la mémoire. Respire et regarde bien.' },
+    { id: 10, mode: LevelModes.READING, rounds: 4, options: 6, timeLimit: 9000, instructions: 'Ultime défi : lis vite et sois précis.' }
+];
+
+const GameState = {
+    playerName: '',
+    currentLevel: 1,
+    currentConfig: LEVELS[0],
+    score: 0,
+    mistakes: 0,
+    incorrectCounts: {},
+    completedRounds: 0,
+    levelStartTime: null,
+    progress: Array.from({ length: LEVELS.length }, () => ({ stars: 0, bestScore: 0 })),
+    highestUnlocked: 1,
+    settings: {
+        speechEnabled: true
+    },
+    modeState: {},
+    load() {
+        const stored = localStorage.getItem(STORAGE_KEY);
+        if (!stored) {
+            return;
+        }
+        try {
+            const data = JSON.parse(stored);
+            this.playerName = data.playerName || '';
+            this.score = data.score || 0;
+            this.incorrectCounts = data.incorrectCounts || {};
+            this.progress = data.progress || this.progress;
+            this.highestUnlocked = data.highestUnlocked || 1;
+            this.settings = Object.assign({}, this.settings, data.settings || {});
+            if (this.playerName) {
+                const nameInput = document.getElementById('name-input');
+                if (nameInput) {
+                    nameInput.value = this.playerName;
+                }
+            }
+        } catch (error) {
+            console.warn('Failed to load saved data', error);
+        }
+    },
+    save() {
+        const data = {
+            playerName: this.playerName,
+            score: this.score,
+            incorrectCounts: this.incorrectCounts,
+            progress: this.progress,
+            highestUnlocked: this.highestUnlocked,
+            settings: this.settings
+        };
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+    },
+    resetForLevel(levelNumber) {
+        this.currentLevel = levelNumber;
+        this.currentConfig = LEVELS[levelNumber - 1];
+        this.mistakes = 0;
+        this.completedRounds = 0;
+        this.levelStartTime = Date.now();
+        this.modeState = {
+            timerId: null,
+            timerInterval: null,
+            awaitingInput: true,
+            sequence: [],
+            playerSequence: []
+        };
+    }
+};
+
+const elements = {};
+
+document.addEventListener('DOMContentLoaded', () => {
+    cacheElements();
+    attachEventListeners();
+    GameState.load();
+    updateScoreDisplay();
+    updateSettingsUI();
+});
+
+function cacheElements() {
+    elements.screens = document.querySelectorAll('.screen');
+    elements.nameInput = document.getElementById('name-input');
+    elements.startButton = document.getElementById('start-button');
+    elements.introBubble = document.getElementById('intro-bubble');
+    elements.playerGreeting = document.getElementById('player-greeting');
+    elements.levelGrid = document.getElementById('level-grid');
+    elements.levelDisplay = document.getElementById('level-display');
+    elements.instructions = document.getElementById('instructions');
+    elements.colorPrompt = document.getElementById('color-prompt');
+    elements.colorGrid = document.getElementById('color-grid');
+    elements.listenButton = document.getElementById('listen-button');
+    elements.scoreDisplay = document.getElementById('score-display');
+    elements.timerDisplay = document.getElementById('timer-display');
+    elements.memoryControls = document.getElementById('memory-controls');
+    elements.replaySequence = document.getElementById('replay-sequence');
+    elements.backToLevels = document.getElementById('back-to-levels');
+    elements.settingsButton = document.getElementById('settings-button');
+    elements.settingsPanel = document.getElementById('settings-panel');
+    elements.speechToggle = document.getElementById('speech-toggle');
+    elements.closeSettings = document.getElementById('close-settings');
+    elements.toast = document.getElementById('toast');
+    elements.levelCompleteTitle = document.getElementById('level-complete-title');
+    elements.starContainer = document.getElementById('star-container');
+    elements.levelStats = document.getElementById('level-stats');
+    elements.nextLevelButton = document.getElementById('next-level-button');
+    elements.replayLevelButton = document.getElementById('replay-level-button');
+    elements.backToMapButton = document.getElementById('back-to-map-button');
+}
+
+function attachEventListeners() {
+    elements.startButton.addEventListener('click', startGame);
+    elements.listenButton.addEventListener('click', playPrompt);
+    elements.replaySequence.addEventListener('click', () => playMemorySequence(false));
+    elements.backToLevels.addEventListener('click', () => showScreen('level-select-screen'));
+    elements.settingsButton.addEventListener('click', toggleSettings);
+    elements.closeSettings.addEventListener('click', hideSettings);
+    elements.speechToggle.addEventListener('change', (event) => {
+        GameState.settings.speechEnabled = event.target.checked;
+        updateSettingsUI();
+        GameState.save();
+    });
+    elements.nextLevelButton.addEventListener('click', () => {
+        const nextLevel = Math.min(GameState.currentLevel + 1, LEVELS.length);
+        if (nextLevel === GameState.currentLevel && GameState.currentLevel === LEVELS.length) {
+            showScreen('level-select-screen');
+            return;
+        }
+        enterLevel(nextLevel);
+    });
+    elements.replayLevelButton.addEventListener('click', () => enterLevel(GameState.currentLevel));
+    elements.backToMapButton.addEventListener('click', () => showScreen('level-select-screen'));
+}
+
+function startGame() {
+    const enteredName = (elements.nameInput.value || '').trim();
+    if (!enteredName) {
+        alert('S\'il te plaît, entre ton nom !');
+        return;
+    }
+    GameState.playerName = enteredName;
+    GameState.save();
+    elements.introBubble.textContent = `Allons-y, ${GameState.playerName} !`;
+    showScreen('intro-screen');
+    setTimeout(() => {
+        populateLevelGrid();
+        updatePlayerGreeting();
+        showScreen('level-select-screen');
+    }, 2400);
+}
+
+function showScreen(id) {
+    elements.screens.forEach((screen) => {
+        if (screen.id === id) {
+            screen.classList.add('active');
+        } else {
+            screen.classList.remove('active');
+        }
+    });
+    if (id === 'level-select-screen') {
+        populateLevelGrid();
+        hideSettings();
+    }
+    if (id === 'game-screen') {
+        hideSettings();
+    }
+}
+
+function populateLevelGrid() {
+    elements.levelGrid.innerHTML = '';
+    LEVELS.forEach((level) => {
+        const card = document.createElement('button');
+        card.className = 'level-card';
+        card.setAttribute('role', 'listitem');
+        card.innerHTML = `
+            <strong>Niveau ${level.id}</strong>
+            <span>${level.instructions}</span>
+            <div class="level-stars" aria-label="Étoiles">${renderStars(GameState.progress[level.id - 1].stars)}</div>
+        `;
+        if (level.id > GameState.highestUnlocked) {
+            card.classList.add('locked');
+        } else {
+            card.addEventListener('click', () => enterLevel(level.id));
+        }
+        elements.levelGrid.appendChild(card);
+    });
+}
+
+function updatePlayerGreeting() {
+    const highest = GameState.highestUnlocked;
+    const starsTotal = GameState.progress.reduce((sum, level) => sum + level.stars, 0);
+    const message = `Salut ${GameState.playerName} ! Tu as gagné ${starsTotal} ⭐ et débloqué le niveau ${highest}.`;
+    elements.playerGreeting.textContent = message;
+}
+
+function enterLevel(levelNumber) {
+    GameState.resetForLevel(levelNumber);
+    elements.levelDisplay.textContent = `Niveau ${levelNumber}`;
+    elements.instructions.textContent = GameState.currentConfig.instructions;
+    elements.colorPrompt.textContent = '';
+    elements.colorGrid.innerHTML = '';
+    elements.memoryControls.classList.add('hidden');
+    elements.listenButton.classList.remove('hidden');
+    clearTimer();
+    GameState.modeState.levelStart = Date.now();
+
+    showScreen('game-screen');
+    if (GameState.currentConfig.mode === LevelModes.MEMORY) {
+        setupMemoryLevel();
+    } else {
+        setupColorMatchLevel();
+    }
+    updateScoreDisplay();
+}
+
+function setupColorMatchLevel() {
+    const { options } = GameState.currentConfig;
+    const roundOptions = selectColorOptions(options);
+    const targetColor = chooseTargetColor(roundOptions);
+    GameState.modeState.currentOptions = roundOptions;
+    GameState.modeState.targetColor = targetColor;
+    GameState.modeState.awaitingInput = true;
+    if (GameState.currentConfig.timeLimit) {
+        startLevelTimer(GameState.currentConfig.timeLimit);
+    } else {
+        clearTimer();
+    }
+    renderColorBoxes(roundOptions);
+
+    if (GameState.currentConfig.mode === LevelModes.READING) {
+        elements.listenButton.textContent = 'Écouter 🔊';
+        elements.colorPrompt.textContent = formatColorName(targetColor);
+    } else {
+        elements.listenButton.textContent = 'Écouter 🔊';
+        elements.colorPrompt.textContent = '';
+    }
+
+    if (GameState.settings.speechEnabled) {
+        setTimeout(() => playPrompt(), 350);
+    }
+}
+
+function setupMemoryLevel() {
+    const config = GameState.currentConfig;
+    const options = selectColorOptions(config.options || 5);
+    const sequence = buildMemorySequence(options, config.sequenceLength || 3);
+
+    GameState.modeState.currentOptions = options;
+    GameState.modeState.sequence = sequence;
+    GameState.modeState.playerSequence = [];
+    GameState.modeState.awaitingInput = false;
+
+    elements.memoryControls.classList.remove('hidden');
+    elements.listenButton.classList.add('hidden');
+    elements.colorPrompt.textContent = 'Regarde la séquence…';
+
+    renderColorBoxes(options, true);
+    setTimeout(() => playMemorySequence(true), 400);
+}
+
+function renderColorBoxes(options, isMemory = false) {
+    elements.colorGrid.innerHTML = '';
+    options.forEach((colorName) => {
+        const colorBox = document.createElement('button');
+        colorBox.className = 'color-box';
+        colorBox.style.backgroundColor = COLOR_LIBRARY[colorName];
+        colorBox.dataset.color = colorName;
+        colorBox.setAttribute('aria-label', `Couleur ${formatColorName(colorName)}`);
+        colorBox.type = 'button';
+        colorBox.addEventListener('click', () => {
+            if (GameState.currentConfig.mode === LevelModes.MEMORY) {
+                handleMemoryChoice(colorName, colorBox);
+            } else {
+                handleColorChoice(colorName, colorBox);
+            }
+        });
+        if (GameState.currentConfig.mode === LevelModes.READING && isMemory === false) {
+            const label = document.createElement('span');
+            label.className = 'color-label';
+            label.textContent = formatColorName(colorName);
+            colorBox.appendChild(label);
+        }
+        elements.colorGrid.appendChild(colorBox);
+    });
+}
+
+function handleColorChoice(colorName, element) {
+    if (!GameState.modeState.awaitingInput) {
+        return;
+    }
+    if (colorName === GameState.modeState.targetColor) {
+        GameState.modeState.awaitingInput = false;
+        element.classList.add('correct');
+        GameState.score += 10;
+        GameState.completedRounds += 1;
+        if (GameState.incorrectCounts[colorName]) {
+            GameState.incorrectCounts[colorName] = Math.max(
+                0,
+                GameState.incorrectCounts[colorName] - 1
+            );
+        }
+        updateScoreDisplay();
+        setTimeout(() => {
+            element.classList.remove('correct');
+            if (GameState.completedRounds >= GameState.currentConfig.rounds) {
+                completeLevel();
+            } else {
+                setupColorMatchLevel();
+                showToast(`Bravo ! Tour ${GameState.completedRounds}/${GameState.currentConfig.rounds}`);
+            }
+        }, 600);
+    } else {
+        element.classList.add('incorrect');
+        registerMistake(colorName);
+        setTimeout(() => element.classList.remove('incorrect'), 800);
+    }
+}
+
+function handleMemoryChoice(colorName, element) {
+    if (!GameState.modeState.awaitingInput) {
+        return;
+    }
+    const step = GameState.modeState.playerSequence.length;
+    const expected = GameState.modeState.sequence[step];
+    if (colorName === expected) {
+        element.classList.add('correct');
+        GameState.modeState.playerSequence.push(colorName);
+        setTimeout(() => element.classList.remove('correct'), 500);
+        if (GameState.modeState.playerSequence.length === GameState.modeState.sequence.length) {
+            GameState.score += 20;
+            GameState.completedRounds = GameState.currentConfig.rounds;
+            updateScoreDisplay();
+            completeLevel();
+        }
+    } else {
+        element.classList.add('incorrect');
+        registerMistake(expected);
+        GameState.modeState.playerSequence = [];
+        GameState.modeState.awaitingInput = false;
+        setTimeout(() => {
+            element.classList.remove('incorrect');
+            playMemorySequence(true);
+        }, 800);
+    }
+}
+
+function playPrompt() {
+    if (!GameState.settings.speechEnabled) {
+        return;
+    }
+    if (GameState.currentConfig.mode === LevelModes.MEMORY) {
+        playMemorySequence(false);
+        return;
+    }
+    const word = GameState.modeState.targetColor;
+    if (!word) {
+        return;
+    }
+    speak(word);
+}
+
+function playMemorySequence(initial) {
+    const sequence = GameState.modeState.sequence || [];
+    const colorButtons = Array.from(elements.colorGrid.querySelectorAll('.color-box'));
+    const buttonMap = new Map(colorButtons.map((button) => [button.dataset.color, button]));
+    if (!sequence.length) {
+        return;
+    }
+    GameState.modeState.playerSequence = [];
+    GameState.modeState.awaitingInput = false;
+    sequence.forEach((colorName, index) => {
+        setTimeout(() => {
+            const button = buttonMap.get(colorName);
+            if (button) {
+                button.classList.add('flash');
+                setTimeout(() => button.classList.remove('flash'), 550);
+            }
+            if (GameState.settings.speechEnabled) {
+                speak(colorName);
+            }
+            if (index === sequence.length - 1) {
+                setTimeout(() => {
+                    GameState.modeState.awaitingInput = true;
+                    elements.colorPrompt.textContent = 'À toi de jouer !';
+                }, 600);
+            }
+        }, index * 900);
+    });
+    if (initial) {
+        elements.colorPrompt.textContent = 'Observe bien…';
+    }
+}
+
+function speak(word) {
+    if (!('speechSynthesis' in window)) {
+        return;
+    }
+    window.speechSynthesis.cancel();
+    const utterance = new SpeechSynthesisUtterance(word);
+    utterance.lang = 'fr-FR';
+    window.speechSynthesis.speak(utterance);
+}
+
+function selectColorOptions(count) {
+    const colorNames = Object.keys(COLOR_LIBRARY);
+    const weightedPool = [];
+    colorNames.forEach((color) => {
+        const mistakes = GameState.incorrectCounts[color] || 0;
+        const weight = Math.min(4, 1 + mistakes);
+        for (let i = 0; i < weight; i += 1) {
+            weightedPool.push(color);
+        }
+    });
+    const uniqueOptions = new Set();
+    while (uniqueOptions.size < count && weightedPool.length) {
+        const randomIndex = Math.floor(Math.random() * weightedPool.length);
+        const [color] = weightedPool.splice(randomIndex, 1);
+        uniqueOptions.add(color);
+    }
+    // If we didn't get enough unique colors (e.g., small pool), fill randomly
+    while (uniqueOptions.size < count) {
+        const color = colorNames[Math.floor(Math.random() * colorNames.length)];
+        uniqueOptions.add(color);
+    }
+    return Array.from(uniqueOptions);
+}
+
+function chooseTargetColor(options) {
+    const reviewCandidates = options
+        .map((color) => ({ color, mistakes: GameState.incorrectCounts[color] || 0 }))
+        .filter(({ mistakes }) => mistakes > 0)
+        .sort((a, b) => b.mistakes - a.mistakes);
+    if (reviewCandidates.length && Math.random() < 0.7) {
+        return reviewCandidates[0].color;
+    }
+    return options[Math.floor(Math.random() * options.length)];
+}
+
+function buildMemorySequence(options, length) {
+    const sequence = [];
+    while (sequence.length < length) {
+        const color = options[Math.floor(Math.random() * options.length)];
+        if (sequence.length === 0 || sequence[sequence.length - 1] !== color) {
+            sequence.push(color);
+        }
+    }
+    return sequence;
+}
+
+function registerMistake(colorName) {
+    GameState.mistakes += 1;
+    if (colorName) {
+        GameState.incorrectCounts[colorName] = (GameState.incorrectCounts[colorName] || 0) + 1;
+    }
+    GameState.score = Math.max(0, GameState.score - 2);
+    updateScoreDisplay();
+    showToast('Essaie encore !');
+}
+
+function completeLevel() {
+    clearTimer();
+    const durationMs = Date.now() - GameState.levelStartTime;
+    const stars = calculateStars(GameState.mistakes);
+    const scoreGain = Math.max(20, GameState.currentConfig.rounds * 15 - GameState.mistakes * 5);
+    GameState.score += scoreGain;
+    updateScoreDisplay();
+
+    const levelIndex = GameState.currentLevel - 1;
+    const previousStars = GameState.progress[levelIndex].stars;
+    GameState.progress[levelIndex] = {
+        stars: Math.max(previousStars, stars),
+        bestScore: Math.max(GameState.progress[levelIndex].bestScore, scoreGain)
+    };
+    if (GameState.currentLevel === GameState.highestUnlocked && GameState.currentLevel < LEVELS.length) {
+        GameState.highestUnlocked += 1;
+    }
+    GameState.save();
+    showLevelCompleteScreen({ stars, scoreGain, durationMs });
+}
+
+function calculateStars(mistakes) {
+    if (mistakes === 0) {
+        return 3;
+    }
+    if (mistakes === 1) {
+        return 2;
+    }
+    return 1;
+}
+
+function showLevelCompleteScreen({ stars, scoreGain, durationMs }) {
+    const seconds = Math.round(durationMs / 1000);
+    elements.levelCompleteTitle.textContent = `Bravo ${GameState.playerName} !`;
+    elements.starContainer.innerHTML = renderStars(stars);
+    elements.levelStats.textContent = `+${scoreGain} points · ${seconds}s · ${GameState.mistakes} erreur(s)`;
+
+    if (GameState.currentLevel >= LEVELS.length) {
+        elements.nextLevelButton.textContent = 'Retour à la carte';
+    } else {
+        elements.nextLevelButton.textContent = `Niveau ${GameState.currentLevel + 1}`;
+    }
+
+    showScreen('level-complete-screen');
+}
+
+function renderStars(count) {
+    return Array.from({ length: 3 }, (_, index) => (index < count ? '★' : '☆')).join(' ');
+}
+
+function updateScoreDisplay() {
+    elements.scoreDisplay.textContent = `Score : ${GameState.score}`;
+}
+
+function startLevelTimer(limitMs) {
+    clearTimer();
+    elements.timerDisplay.classList.remove('hidden');
+    const endTime = Date.now() + limitMs;
+    elements.timerDisplay.textContent = `${Math.ceil(limitMs / 1000)}s`;
+    GameState.modeState.timerInterval = setInterval(() => {
+        const remaining = Math.max(0, endTime - Date.now());
+        const seconds = Math.ceil(remaining / 1000);
+        elements.timerDisplay.textContent = `${seconds}s`;
+        if (remaining <= 0) {
+            registerMistake();
+            clearTimer();
+            showToast('Temps écoulé !');
+            setupColorMatchLevel();
+        }
+    }, 500);
+}
+
+function clearTimer() {
+    elements.timerDisplay.classList.add('hidden');
+    if (GameState.modeState.timerInterval) {
+        clearInterval(GameState.modeState.timerInterval);
+        GameState.modeState.timerInterval = null;
+    }
+}
+
+function toggleSettings() {
+    const isHidden = elements.settingsPanel.classList.contains('hidden');
+    if (isHidden) {
+        elements.settingsPanel.classList.remove('hidden');
+        elements.settingsPanel.setAttribute('aria-hidden', 'false');
+        elements.settingsButton.setAttribute('aria-expanded', 'true');
+    } else {
+        hideSettings();
+    }
+}
+
+function hideSettings() {
+    elements.settingsPanel.classList.add('hidden');
+    elements.settingsPanel.setAttribute('aria-hidden', 'true');
+    elements.settingsButton.setAttribute('aria-expanded', 'false');
+}
+
+function updateSettingsUI() {
+    if (elements.speechToggle) {
+        elements.speechToggle.checked = GameState.settings.speechEnabled;
+    }
+}
+
+function formatColorName(colorName) {
+    if (!colorName) {
+        return '';
+    }
+    return colorName.charAt(0).toUpperCase() + colorName.slice(1);
+}
+
+function showToast(message) {
+    if (!elements.toast) {
+        return;
+    }
+    elements.toast.textContent = message;
+    elements.toast.classList.add('visible');
+    setTimeout(() => {
+        elements.toast.classList.remove('visible');
+    }, 1200);
+}

--- a/style.css
+++ b/style.css
@@ -1,0 +1,376 @@
+/* Base Layout */
+:root {
+    --primary: #3498db;
+    --primary-dark: #2980b9;
+    --success: #2ecc71;
+    --danger: #e74c3c;
+    --surface: #ffffff;
+    --surface-alt: #f0f4f8;
+    --text: #2c3e50;
+    --shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
+}
+
+* {
+    box-sizing: border-box;
+}
+
+body {
+    margin: 0;
+    min-height: 100vh;
+    font-family: "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+    background: linear-gradient(180deg, #f8fbff 0%, #dfe9f3 100%);
+    color: var(--text);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 1.5rem;
+}
+
+.app-container {
+    background: var(--surface);
+    border-radius: 20px;
+    width: 100%;
+    max-width: 420px;
+    box-shadow: var(--shadow);
+    padding: 1.5rem;
+    position: relative;
+}
+
+.app-header {
+    text-align: center;
+    margin-bottom: 1rem;
+}
+
+.app-header h1 {
+    margin: 0;
+    font-size: 1.8rem;
+}
+
+main {
+    position: relative;
+}
+
+.screen {
+    display: none;
+    animation: fadeIn 0.3s ease;
+}
+
+.screen.active {
+    display: block;
+}
+
+@keyframes fadeIn {
+    from {
+        opacity: 0;
+        transform: translateY(10px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+/* Intro character */
+.intro-character-container {
+    position: relative;
+    height: 160px;
+    display: flex;
+    align-items: flex-end;
+    justify-content: center;
+    margin-top: 2rem;
+}
+
+.pixel-char {
+    width: 60px;
+    height: 80px;
+    background: #d9534f;
+    position: relative;
+    box-shadow:
+        0 -12px 0 0 #d9534f,
+        12px -12px 0 0 #d9534f,
+        -12px -12px 0 0 #d9534f,
+        0 0 0 0 #f0ad4e,
+        -6px -6px 0 0 #fff,
+        6px -6px 0 0 #fff,
+        -6px -6px 0 1px #000,
+        6px -6px 0 1px #000,
+        -12px 12px 0 0 #337ab7,
+        12px 12px 0 0 #337ab7,
+        -12px 24px 0 0 #337ab7,
+        12px 24px 0 0 #337ab7;
+}
+
+.speech-bubble {
+    position: absolute;
+    background: var(--surface-alt);
+    border-radius: 16px;
+    padding: 1rem;
+    font-size: 1.1rem;
+    bottom: 100px;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 85%;
+    box-shadow: var(--shadow);
+}
+
+.speech-bubble::after {
+    content: "";
+    position: absolute;
+    bottom: -12px;
+    left: 50%;
+    margin-left: -12px;
+    border-width: 12px;
+    border-style: solid;
+    border-color: var(--surface-alt) transparent transparent transparent;
+}
+
+/* Buttons */
+button {
+    font-size: 1.1rem;
+    border: none;
+    border-radius: 12px;
+    padding: 0.75rem 1.25rem;
+    cursor: pointer;
+    transition: transform 0.15s ease, box-shadow 0.2s ease;
+}
+
+button:focus-visible {
+    outline: 3px solid var(--primary);
+    outline-offset: 2px;
+}
+
+button:active {
+    transform: scale(0.97);
+}
+
+.primary {
+    background: var(--primary);
+    color: #fff;
+    box-shadow: 0 6px 12px rgba(52, 152, 219, 0.3);
+}
+
+.primary:hover {
+    background: var(--primary-dark);
+}
+
+.ghost-button {
+    background: transparent;
+    color: var(--text);
+    padding: 0.5rem 0.75rem;
+}
+
+/* Forms */
+input[type="text"] {
+    width: 100%;
+    padding: 0.85rem;
+    font-size: 1.2rem;
+    border-radius: 12px;
+    border: 2px solid #dbe3eb;
+    margin-bottom: 1rem;
+    text-align: center;
+}
+
+/* Level selection */
+.level-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+    gap: 1rem;
+    margin-top: 1.5rem;
+}
+
+.level-card {
+    background: var(--surface-alt);
+    border-radius: 16px;
+    padding: 1rem;
+    text-align: center;
+    box-shadow: var(--shadow);
+    position: relative;
+}
+
+.level-card.locked {
+    opacity: 0.5;
+    pointer-events: none;
+}
+
+.level-card strong {
+    display: block;
+    font-size: 1.2rem;
+    margin-bottom: 0.25rem;
+}
+
+.level-card .level-stars {
+    margin-top: 0.5rem;
+    color: #f1c40f;
+}
+
+/* Game screen */
+.game-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 1rem;
+}
+
+.score-panel {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.instructions {
+    font-size: 1rem;
+    margin-bottom: 0.5rem;
+    min-height: 3rem;
+}
+
+.color-prompt {
+    font-size: 1.6rem;
+    font-weight: 600;
+    margin-bottom: 1rem;
+}
+
+.color-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 1rem;
+}
+
+.color-box {
+    border-radius: 16px;
+    height: 110px;
+    cursor: pointer;
+    border: 4px solid transparent;
+    transition: transform 0.15s ease, border-color 0.3s ease;
+}
+
+.color-box:hover,
+.color-box:focus-visible {
+    transform: scale(1.03);
+}
+
+.color-box.correct {
+    border-color: var(--success);
+}
+
+.color-box.incorrect {
+    border-color: var(--danger);
+}
+
+.color-label {
+    background: rgba(255, 255, 255, 0.8);
+    padding: 0.25rem 0.5rem;
+    border-radius: 8px;
+    display: inline-block;
+    margin-top: 0.5rem;
+    font-weight: 600;
+}
+
+.timer {
+    display: inline-block;
+    font-size: 0.95rem;
+    margin-left: 0.5rem;
+}
+
+.hidden {
+    display: none !important;
+}
+
+.memory-controls {
+    margin-top: 1rem;
+    text-align: center;
+}
+
+/* Level complete */
+.stars {
+    display: flex;
+    justify-content: center;
+    gap: 0.5rem;
+    font-size: 2rem;
+    margin: 1rem 0;
+    color: #f1c40f;
+}
+
+.level-complete-actions {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    align-items: center;
+}
+
+/* Settings */
+.settings {
+    position: absolute;
+    top: 1rem;
+    right: 1rem;
+    background: var(--surface);
+    border-radius: 16px;
+    padding: 1rem;
+    box-shadow: var(--shadow);
+    width: 220px;
+    z-index: 10;
+}
+
+.settings h2 {
+    margin-top: 0;
+    font-size: 1.2rem;
+}
+
+.toggle {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 1rem;
+}
+
+.settings-hint {
+    font-size: 0.85rem;
+    color: #546a7b;
+}
+
+/* Toast */
+.toast {
+    position: fixed;
+    bottom: 1.5rem;
+    left: 50%;
+    transform: translateX(-50%);
+    background: #1f2933;
+    color: #fff;
+    padding: 0.75rem 1.25rem;
+    border-radius: 999px;
+    box-shadow: var(--shadow);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.3s ease;
+}
+
+.toast.visible {
+    opacity: 1;
+}
+
+/* Responsive tweaks */
+@media (min-width: 500px) {
+    .color-grid {
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+}
+
+@media (min-width: 700px) {
+    body {
+        padding: 2rem;
+    }
+
+    .app-container {
+        max-width: 500px;
+    }
+}
+
+.color-box.flash {
+    animation: flash 0.6s ease;
+}
+
+@keyframes flash {
+    0% { transform: scale(1); box-shadow: 0 0 0 0 rgba(255, 255, 255, 0.7); }
+    50% { transform: scale(1.05); box-shadow: 0 0 0 12px rgba(255, 255, 255, 0); }
+    100% { transform: scale(1); box-shadow: 0 0 0 0 rgba(255, 255, 255, 0); }
+}


### PR DESCRIPTION
## Summary
- split the single-page prototype into dedicated HTML, CSS, and JavaScript files with a refreshed kid-friendly layout and settings overlay
- implement a ten-level progression that mixes listening, reading, and memory challenges with adaptive review logic and expanded color vocabulary
- add level selection and completion flows with score, star tracking, localStorage saves, and voice toggles to support replayability

## Testing
- not run (frontend app)


------
https://chatgpt.com/codex/tasks/task_e_68d0310114108327a182ed2b2b4beba9