### PR TITLE
Fix map tiles blocking game launch

### DIFF
--- a/style.css
+++ b/style.css
@@ -279,6 +279,7 @@ input[type="text"]:focus {
   inset: 0;
   background: radial-gradient(circle at top, rgba(255, 255, 255, 0.6), transparent 60%);
   opacity: 0;
+  pointer-events: none;
   transition: opacity 0.3s ease;
 }
 


### PR DESCRIPTION
## Summary
- stop the translucent map tile overlay from intercepting pointer events so the adventure buttons receive clicks again

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d0432fb9b0832785d0eab80543f68f