### PR TITLE
Ensure French voice selection and enhance Camy design

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,7 +31,22 @@
         <section id="home-screen" class="screen active">
             <div class="hero">
                 <div class="mascot" aria-hidden="true">
-                    <div class="mascot-body"></div>
+                    <div class="mascot-shadow"></div>
+                    <div class="mascot-tail"></div>
+                    <div class="mascot-body">
+                        <div class="mascot-belly"></div>
+                        <div class="mascot-spot spot-1"></div>
+                        <div class="mascot-spot spot-2"></div>
+                        <div class="mascot-spot spot-3"></div>
+                    </div>
+                    <div class="mascot-head">
+                        <div class="mascot-eye">
+                            <div class="mascot-eye-inner"></div>
+                        </div>
+                        <div class="mascot-mouth"></div>
+                    </div>
+                    <div class="mascot-leg back"></div>
+                    <div class="mascot-leg front"></div>
                     <div class="mascot-brush"></div>
                 </div>
                 <div class="hero-copy">

--- a/style.css
+++ b/style.css
@@ -181,13 +181,113 @@ h1 {
   margin-inline: auto;
 }
 
+.mascot-shadow {
+  position: absolute;
+  bottom: 8%;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 70%;
+  height: 18%;
+  background: radial-gradient(circle at 50% 50%, rgba(15, 23, 42, 0.35), rgba(15, 23, 42, 0));
+  filter: blur(8px);
+  opacity: 0.55;
+  z-index: 0;
+}
+
+.mascot-tail {
+  position: absolute;
+  right: 0;
+  top: 34%;
+  width: 52%;
+  height: 52%;
+  border-radius: 60% 40% 55% 45% / 50% 55% 45% 50%;
+  background: radial-gradient(circle at 35% 35%, #d9f99d 0%, #4ade80 45%, #16a34a 85%);
+  box-shadow: 0 18px 28px rgba(14, 116, 144, 0.22);
+  transform-origin: left center;
+  animation: tailSwing 5.5s ease-in-out infinite;
+  z-index: 1;
+}
+
+.mascot-tail::before {
+  content: '';
+  position: absolute;
+  bottom: -10%;
+  right: -6%;
+  width: 44%;
+  height: 44%;
+  border-radius: 50%;
+  border: 6px solid rgba(255, 255, 255, 0.35);
+  border-left-color: transparent;
+  border-bottom-color: transparent;
+  transform: rotate(24deg);
+}
+
+.mascot-tail::after {
+  content: '';
+  position: absolute;
+  inset: 18% 22% 24% 22%;
+  border-radius: 50%;
+  background: radial-gradient(circle at 40% 30%, rgba(255, 255, 255, 0.6), rgba(255, 255, 255, 0));
+  opacity: 0.7;
+}
+
 .mascot-body {
   position: absolute;
-  inset: 0;
-  border-radius: 45% 55% 40% 60% / 50% 45% 55% 50%;
-  background: radial-gradient(circle at 30% 30%, #bef264, #4ade80 65%, #16a34a);
+  top: 24%;
+  left: 20%;
+  width: 58%;
+  height: 52%;
+  border-radius: 58% 42% 48% 52% / 55% 48% 52% 45%;
+  background: radial-gradient(circle at 36% 30%, #d9f99d 0%, #86efac 42%, #22c55e 78%, #166534 100%);
   animation: wave 4s ease-in-out infinite;
   box-shadow: 0 25px 35px rgba(14, 116, 144, 0.25);
+  overflow: hidden;
+  z-index: 2;
+}
+
+.mascot-body::after {
+  content: '';
+  position: absolute;
+  inset: 16% 18% 20% 32%;
+  border-radius: 60% 45% 55% 50%;
+  background: radial-gradient(circle at 50% 25%, rgba(255, 255, 255, 0.9), rgba(255, 255, 255, 0));
+  opacity: 0.85;
+}
+
+.mascot-belly {
+  position: absolute;
+  inset: 32% 24% 20% 36%;
+  border-radius: 55% 50% 50% 45%;
+  background: radial-gradient(circle at 48% 22%, rgba(255, 255, 255, 0.95), rgba(255, 255, 255, 0));
+  filter: saturate(120%);
+}
+
+.mascot-spot {
+  position: absolute;
+  border-radius: 50%;
+  background: radial-gradient(circle at 30% 30%, rgba(163, 230, 53, 0.9), rgba(21, 128, 61, 0.85));
+  opacity: 0.75;
+}
+
+.spot-1 {
+  width: 26%;
+  height: 26%;
+  top: 18%;
+  left: 16%;
+}
+
+.spot-2 {
+  width: 20%;
+  height: 20%;
+  bottom: 24%;
+  right: 14%;
+}
+
+.spot-3 {
+  width: 18%;
+  height: 18%;
+  top: 46%;
+  right: 24%;
 }
 
 @keyframes wave {
@@ -195,16 +295,199 @@ h1 {
   50% { transform: rotate(4deg) translateY(-6px); }
 }
 
+@keyframes tailSwing {
+  0%, 100% { transform: rotate(26deg) scale(1); }
+  50% { transform: rotate(36deg) scale(1.05); }
+}
+
+.mascot-head {
+  position: absolute;
+  top: 12%;
+  left: 2%;
+  width: 42%;
+  height: 42%;
+  border-radius: 58% 42% 50% 60% / 50% 40% 60% 50%;
+  background: radial-gradient(circle at 38% 32%, #ecfccb, #4ade80 70%, #16a34a 100%);
+  box-shadow: 0 18px 26px rgba(14, 116, 144, 0.22);
+  transform: rotate(-8deg);
+  z-index: 3;
+}
+
+.mascot-head::before {
+  content: '';
+  position: absolute;
+  top: -18%;
+  left: 24%;
+  width: 58%;
+  height: 34%;
+  border-radius: 60% 60% 0 0;
+  background: linear-gradient(135deg, rgba(190, 242, 100, 0.95), rgba(34, 197, 94, 0.55));
+  transform: rotate(-10deg);
+  box-shadow: 0 8px 12px rgba(34, 197, 94, 0.25);
+}
+
+.mascot-head::after {
+  content: '';
+  position: absolute;
+  bottom: 18%;
+  left: 20%;
+  width: 32%;
+  height: 28%;
+  border-radius: 50%;
+  background: radial-gradient(circle at 50% 50%, rgba(253, 224, 71, 0.4), rgba(253, 224, 71, 0));
+}
+
+.mascot-eye {
+  position: absolute;
+  width: 34%;
+  height: 34%;
+  top: 32%;
+  right: 20%;
+  background: #f8fafc;
+  border-radius: 50%;
+  box-shadow: inset -2px -2px 0 rgba(14, 116, 144, 0.2);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+}
+
+.mascot-eye::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  background: linear-gradient(180deg, rgba(16, 185, 129, 0.9), rgba(21, 128, 61, 0.6));
+  transform-origin: top center;
+  transform: scaleY(0);
+  animation: blink 6.2s ease-in-out infinite;
+}
+
+.mascot-eye-inner {
+  position: relative;
+  width: 46%;
+  height: 46%;
+  border-radius: 50%;
+  background: radial-gradient(circle at 40% 30%, #0f172a, #14532d 65%);
+  animation: lookAround 7s ease-in-out infinite;
+  z-index: 1;
+}
+
+.mascot-eye-inner::after {
+  content: '';
+  position: absolute;
+  top: 22%;
+  left: 28%;
+  width: 28%;
+  height: 28%;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.8);
+}
+
+@keyframes blink {
+  0%, 46%, 48%, 100% { transform: scaleY(0); }
+  47% { transform: scaleY(1); }
+}
+
+@keyframes lookAround {
+  0%, 18%, 100% { transform: translate(0, 0); }
+  28%, 34% { transform: translate(-2px, 1px); }
+  46%, 54% { transform: translate(2px, -1px); }
+  68%, 76% { transform: translate(1px, 2px); }
+}
+
+.mascot-mouth {
+  position: absolute;
+  bottom: 24%;
+  right: 22%;
+  width: 32%;
+  height: 20%;
+  border-bottom: 3px solid #166534;
+  border-radius: 0 0 50% 50%;
+  transform: rotate(6deg);
+}
+
+.mascot-mouth::after {
+  content: '';
+  position: absolute;
+  right: 12%;
+  top: 16%;
+  width: 40%;
+  height: 30%;
+  border-radius: 50%;
+  background: radial-gradient(circle at 50% 20%, rgba(255, 255, 255, 0.65), rgba(255, 255, 255, 0));
+}
+
+.mascot-leg {
+  position: absolute;
+  bottom: 14%;
+  width: 22%;
+  height: 30%;
+  border-radius: 60% 40% 35% 35%;
+  background: linear-gradient(180deg, #22c55e 0%, #15803d 100%);
+  box-shadow: 0 12px 18px rgba(14, 116, 144, 0.2);
+}
+
+.mascot-leg::after {
+  content: '';
+  position: absolute;
+  bottom: -10%;
+  left: 12%;
+  width: 76%;
+  height: 32%;
+  border-radius: 50% 50% 45% 45%;
+  background: radial-gradient(circle at 40% 40%, #fef3c7, #f59e0b 80%);
+  box-shadow: 0 6px 10px rgba(217, 119, 6, 0.25);
+}
+
+.mascot-leg.back {
+  left: 50%;
+  transform: scaleX(-1) rotate(8deg);
+  opacity: 0.85;
+  z-index: 1;
+}
+
+.mascot-leg.front {
+  left: 28%;
+  transform: rotate(4deg);
+  z-index: 4;
+}
+
 .mascot-brush {
   position: absolute;
   bottom: 12%;
-  right: 5%;
-  width: 40%;
-  height: 14%;
+  right: -4%;
+  width: 44%;
+  height: 15%;
   background: linear-gradient(90deg, #92400e 0%, #f97316 100%);
-  border-radius: 20px;
-  transform: rotate(15deg);
-  box-shadow: 0 10px 16px rgba(124, 45, 18, 0.25);
+  border-radius: 22px;
+  transform: rotate(14deg);
+  box-shadow: 0 12px 18px rgba(124, 45, 18, 0.28);
+  z-index: 5;
+}
+
+.mascot-brush::before {
+  content: '';
+  position: absolute;
+  left: -12%;
+  top: 32%;
+  width: 24%;
+  height: 48%;
+  border-radius: 12px;
+  background: linear-gradient(180deg, #78350f, #451a03);
+}
+
+.mascot-brush::after {
+  content: '';
+  position: absolute;
+  right: -16%;
+  top: -28%;
+  width: 32%;
+  height: 168%;
+  border-radius: 12px;
+  background: linear-gradient(180deg, #fde68a 0%, #f59e0b 45%, #d97706 100%);
+  transform: rotate(-6deg);
+  box-shadow: 0 8px 14px rgba(217, 119, 6, 0.26);
 }
 
 .hero-copy h2 {


### PR DESCRIPTION
## Summary
- force speech synthesis to prefer a French voice while keeping a French fallback in both app scripts
- rebuild Camy the chameleon with layered HTML/CSS for a more detailed mascot illustration

## Testing
- No automated tests were run (project has no test suite)


------
https://chatgpt.com/codex/tasks/task_e_68d0469c03c88327b185a3c4612ccc9c